### PR TITLE
Set ddl auto to create in dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ Recommended IntelliJ plugin: [JS GraphQL](https://plugins.jetbrains.com/plugin/8
 
 1. Import as a Gradle project into your favourite IDE
 2. Start the MySQL Database or run the docker-compose file `docker-compose up -d` (you may need to add `sudo` to this command)
-3. Run `BooksApiApplication.java`
-4. Go to `localhost:8080/graphiql`
+3. Set the active Spring profile to dev (see how to do this in [IntelliJ](https://github.com/Project-Books/books-api/wiki/Change-active-Spring-profile-in-IntelliJ))
+4. Run `BooksApiApplication.java`
+5. Go to `localhost:8080/graphiql`
 
 Sample query:
 ```graphql

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,12 +1,10 @@
 spring.banner.image.location=banner.txt
 
 spring.jpa.open-in-view=false
-spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.hibernate.ddl-auto=create
 
 spring.datasource.url = jdbc:mysql://localhost:3307/booksapi
 spring.datasource.username = dbuser
 spring.datasource.password = dbpassword
 
 spring.flyway.enabled = true
-
-#graphql.servlet.maxQueryDepth=3 TODO: raise to a sensible number (this is set too low)

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,7 @@
+spring.jpa.open-in-view=false
+
+spring.datasource.url = jdbc:mysql://localhost:3307/booksapi
+spring.datasource.username = dbuser
+spring.datasource.password = dbpassword
+
+spring.flyway.enabled = true


### PR DESCRIPTION
## Summary of change

Set ddl auto to `create`. This will recreate the schema every time the app is started.

`application.properties` has been renamed to `application-dev.properties` (to be used for local development). There is now also a prod properties file.

## Related issue

Closes #75 

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [ ] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

For any of the optional checkboxes (e.g. the screenshots one), still check it if it does not apply.

If in doubt, get in touch with us via our Slack workspace or by creating a new [Q&A discussion on GitHub](https://github.com/Project-Books/books-api/discussions/categories/q-a)
