### PR TITLE
Add mutation to delete an Author and all of its books

### DIFF
--- a/src/main/java/com/karankumar/booksapi/mutations/AuthorMutation.java
+++ b/src/main/java/com/karankumar/booksapi/mutations/AuthorMutation.java
@@ -21,12 +21,17 @@ import com.karankumar.booksapi.service.AuthorService;
 import com.netflix.graphql.dgs.DgsComponent;
 import com.netflix.graphql.dgs.DgsData;
 import graphql.schema.DataFetchingEnvironment;
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.HashSet;
+import java.util.Optional;
 
 @DgsComponent
 public class AuthorMutation {
     private final AuthorService authorService;
+    public static final String NOT_FOUND_ERROR_MESSAGE = "Author not found";
 
     public AuthorMutation(AuthorService authorService) {
         this.authorService = authorService;
@@ -36,5 +41,24 @@ public class AuthorMutation {
     public Author addAuthor(DataFetchingEnvironment dataFetchingEnvironment) {
         String fullName = dataFetchingEnvironment.getArgument(DgsConstants.AUTHOR.FullName);
         return authorService.save(new Author(fullName, new HashSet<>()));
+    }
+
+    @DgsData(parentType = DgsConstants.MUTATION.TYPE_NAME, field = DgsConstants.MUTATION.DeleteAuthor)
+    @Transactional
+    public Author deleteAuthor(DataFetchingEnvironment dataFetchingEnvironment) {
+        String stringId = dataFetchingEnvironment.getArgument(DgsConstants.AUTHOR.Id);
+        if (stringId == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, NOT_FOUND_ERROR_MESSAGE);
+        }
+        Long id = Long.parseLong(stringId);
+
+        Optional<Author> author = authorService.findById(id);
+        if (author.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, NOT_FOUND_ERROR_MESSAGE);
+        }
+
+        authorService.deleteAuthor(author.get());
+
+        return author.get();
     }
 }

--- a/src/main/java/com/karankumar/booksapi/repository/NativeQueryRepository.java
+++ b/src/main/java/com/karankumar/booksapi/repository/NativeQueryRepository.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2021  Karan Kumar
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.karankumar.booksapi.repository;
+
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Repository
+public class NativeQueryRepository {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public void deleteAllAuthorAssociations(Long authorId) {
+        entityManager.createNativeQuery("DELETE FROM book_author WHERE author_id = :authorId")
+                .setParameter("authorId", authorId)
+                .executeUpdate();
+    }
+}

--- a/src/main/resources/schema/mutation.graphqls
+++ b/src/main/resources/schema/mutation.graphqls
@@ -2,4 +2,5 @@ type Mutation {
     addIsbn13(id: ID!, isbn13: String): Book
     addAuthor(fullName: String!): Author
     deleteBook(id: ID!): Book
+    deleteAuthor(id: ID!): Author
 }

--- a/src/test/java/com/karankumar/booksapi/mutations/AuthorMutationTest.java
+++ b/src/test/java/com/karankumar/booksapi/mutations/AuthorMutationTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2021  Karan Kumar
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.karankumar.booksapi.mutations;
+
+import com.karankumar.booksapi.DgsConstants;
+import com.karankumar.booksapi.model.Author;
+import com.karankumar.booksapi.model.Book;
+import com.karankumar.booksapi.model.BookFormat;
+import com.karankumar.booksapi.model.BookGenre;
+import com.karankumar.booksapi.model.Language;
+import com.karankumar.booksapi.service.AuthorService;
+import graphql.schema.DataFetchingEnvironment;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+
+import static com.karankumar.booksapi.mutations.AuthorMutation.NOT_FOUND_ERROR_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class AuthorMutationTest {
+
+    @MockBean
+    private AuthorService authorService;
+
+    @Autowired
+    private AuthorMutation underTest;
+
+    @MockBean
+    private DataFetchingEnvironment dataFetchingEnvironment;
+
+    @Test
+    public void deleteAuthor_throws_whenIdWasNotFound() {
+        // given
+        when(dataFetchingEnvironment.getArgument(DgsConstants.AUTHOR.Id)).thenReturn(null);
+
+        // when/then
+        ResponseStatusException exception = Assertions.assertThrows(ResponseStatusException.class,
+                () -> underTest.deleteAuthor(dataFetchingEnvironment));
+
+        assertThat(exception.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(exception.getReason()).isEqualTo(NOT_FOUND_ERROR_MESSAGE);
+    }
+
+    @Test
+    public void deleteAuthor_throws_whenAuthorWasNotFound() {
+        // given
+        when(dataFetchingEnvironment.getArgument(DgsConstants.AUTHOR.Id)).thenReturn("1");
+        when(authorService.findById(1L)).thenReturn(Optional.empty());
+
+        // when/then
+        ResponseStatusException exception = Assertions.assertThrows(ResponseStatusException.class,
+                () -> underTest.deleteAuthor(dataFetchingEnvironment));
+
+        verify(authorService, times(1)).findById(1L);
+
+        assertThat(exception.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(exception.getReason()).isEqualTo(NOT_FOUND_ERROR_MESSAGE);
+    }
+
+    @Test
+    public void deleteAuthor_shouldDeletedReturnAuthor_whenAuthorWasDeleted() {
+        // given
+        Book book = new Book("TestTitle", Language.AFRIKAANS, "Blurb", BookGenre.ADVENTURE, BookFormat.HARDCOVER);
+        Author author = new Author("Test Author", new HashSet<>(Collections.singletonList(book)));
+
+        when(dataFetchingEnvironment.getArgument(DgsConstants.AUTHOR.Id)).thenReturn("1");
+        when(authorService.findById(1L)).thenReturn(Optional.of(author));
+
+        // when
+        Author resultAuthor = underTest.deleteAuthor(dataFetchingEnvironment);
+
+        // then
+        verify(authorService, times(1)).deleteAuthor(author);
+
+        assertThat(resultAuthor).isSameAs(author);
+    }
+
+}

--- a/src/test/java/com/karankumar/booksapi/service/AuthorServiceIntegrationTest.java
+++ b/src/test/java/com/karankumar/booksapi/service/AuthorServiceIntegrationTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2021  Karan Kumar
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.karankumar.booksapi.service;
+
+import com.karankumar.booksapi.annotations.DataJpaIntegrationTest;
+import com.karankumar.booksapi.model.Author;
+import com.karankumar.booksapi.model.Book;
+import com.karankumar.booksapi.model.BookFormat;
+import com.karankumar.booksapi.model.BookGenre;
+import com.karankumar.booksapi.model.Language;
+import com.karankumar.booksapi.repository.AuthorRepository;
+import com.karankumar.booksapi.repository.BookRepository;
+import com.karankumar.booksapi.repository.NativeQueryRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+@DataJpaIntegrationTest
+@Import({NativeQueryRepository.class, AuthorService.class})
+public class AuthorServiceIntegrationTest {
+
+    private AuthorService underTest;
+    private AuthorRepository authorRepository;
+    private BookRepository bookRepository;
+    private NativeQueryRepository nativeQueryRepository;
+
+    @Autowired
+    public AuthorServiceIntegrationTest(AuthorService underTest, AuthorRepository authorRepository, BookRepository bookRepository, NativeQueryRepository nativeQueryRepository) {
+        this.underTest = underTest;
+        this.authorRepository = authorRepository;
+        this.bookRepository = bookRepository;
+        this.nativeQueryRepository = nativeQueryRepository;
+    }
+
+    @Test
+    public void deleteAuthor_whenAuthorHasNoRelations() {
+        // given
+        Author author = new Author("Joe Doe", Collections.emptySet());
+        authorRepository.save(author);
+
+        // when
+        underTest.deleteAuthor(author);
+
+        //then
+        Assertions.assertThat(authorRepository.findById(author.getId())).isNotPresent();
+    }
+
+    @Test
+    public void deleteAuthor_whenAuthorHasExclusiveRelationWithBook() {
+        // given
+        Book book = createBook("Test book");
+        Author author = new Author("Joe Doe", new HashSet<>(Collections.singletonList(book)));
+        authorRepository.save(author);
+        bookRepository.save(book);
+
+        // when
+        underTest.deleteAuthor(author);
+
+        //then
+        Assertions.assertThat(authorRepository.findById(author.getId())).isNotPresent();
+        Assertions.assertThat(bookRepository.findById(book.getId())).isNotPresent();
+    }
+
+    @Test
+    public void deleteAuthor_shouldDeleteOnlyBookExclusiveForDeletedAuthor() {
+        // given
+        Book book = createBook("Exclusive relation with deleted author");
+        Book bookWithMultipleAuthors = createBook("Multiple authors");
+
+        Author authorToDelete = new Author("Joe Doe", new HashSet<>(Arrays.asList(book, bookWithMultipleAuthors)));
+        Author author = new Author("Test Author", new HashSet<>(Collections.singletonList(bookWithMultipleAuthors)));
+        authorRepository.save(authorToDelete);
+        authorRepository.save(author);
+        bookRepository.save(book);
+        bookRepository.save(bookWithMultipleAuthors);
+
+        // when
+        underTest.deleteAuthor(authorToDelete);
+
+        //then
+        Assertions.assertThat(authorRepository.findById(authorToDelete.getId())).isNotPresent();
+        Assertions.assertThat(authorRepository.findById(author.getId())).isPresent();
+        Assertions.assertThat(bookRepository.findById(book.getId())).isNotPresent();
+        Assertions.assertThat(bookRepository.findById(bookWithMultipleAuthors.getId())).isPresent();
+    }
+
+    private Book createBook(String title) {
+        Book book = new Book(
+                title,
+                Language.ENGLISH,
+                "Test Blurb",
+                BookGenre.SATIRE,
+                BookFormat.HARDCOVER
+        );
+
+        return book;
+    }
+}

--- a/src/test/java/com/karankumar/booksapi/service/AuthorServiceTest.java
+++ b/src/test/java/com/karankumar/booksapi/service/AuthorServiceTest.java
@@ -16,6 +16,8 @@ package com.karankumar.booksapi.service;
 
 import com.karankumar.booksapi.model.Author;
 import com.karankumar.booksapi.repository.AuthorRepository;
+import com.karankumar.booksapi.repository.BookRepository;
+import com.karankumar.booksapi.repository.NativeQueryRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,7 +28,6 @@ import java.util.HashSet;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -36,11 +37,15 @@ import static org.mockito.Mockito.verify;
 class AuthorServiceTest {
     private AuthorService underTest;
     private AuthorRepository authorRepository;
+    private BookRepository bookRepository;
+    private NativeQueryRepository nativeQueryRepository;
 
     @BeforeEach
     void setUp() {
         authorRepository = mock(AuthorRepository.class);
-        underTest = new AuthorService(authorRepository);
+        underTest = new AuthorService(authorRepository, bookRepository, nativeQueryRepository);
+        nativeQueryRepository = mock(NativeQueryRepository.class);
+        bookRepository = mock(BookRepository.class);
     }
 
     @Test


### PR DESCRIPTION
## Summary of change

Added mutation which allows delete author with its books (only if there are no relations with other authors left).
I had to delete `V010__RENAME_PUBLISHER_BOOK_CONSTRAINTS.sql` during tests.


## Related issue

Closes #90 

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [ ] Set this pull request to 'draft' if you are still working on it

- [ ] Resolved any merge conflicts

For any of the optional checkboxes (e.g. the screenshots one), still check it if it does not apply.

If in doubt, get in touch with us via our Slack workspace or by creating a new [Q&A discussion on GitHub](https://github.com/Project-Books/books-api/discussions/categories/q-a)
