### PR TITLE
Add security to mutations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
 
 		<dependency>
 			<scope>compile</scope>
@@ -81,6 +85,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/main/java/com/karankumar/booksapi/config/SecurityConfig.java
+++ b/src/main/java/com/karankumar/booksapi/config/SecurityConfig.java
@@ -1,0 +1,26 @@
+package com.karankumar.booksapi.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+@EnableGlobalMethodSecurity(securedEnabled = true)
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    public void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth.inMemoryAuthentication().withUser("admin").password("{noop}1234").roles("ADMIN");
+    }
+
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        http
+                .csrf()
+                .disable()
+                .authorizeRequests()
+                .anyRequest().permitAll();
+    }
+}

--- a/src/main/java/com/karankumar/booksapi/mutations/AuthorMutation.java
+++ b/src/main/java/com/karankumar/booksapi/mutations/AuthorMutation.java
@@ -21,9 +21,11 @@ import com.karankumar.booksapi.service.AuthorService;
 import com.netflix.graphql.dgs.DgsComponent;
 import com.netflix.graphql.dgs.DgsData;
 import graphql.schema.DataFetchingEnvironment;
+import org.springframework.security.access.annotation.Secured;
 
 import java.util.HashSet;
 
+@Secured("ROLE_ADMIN")
 @DgsComponent
 public class AuthorMutation {
     private final AuthorService authorService;

--- a/src/main/java/com/karankumar/booksapi/mutations/BookMutation.java
+++ b/src/main/java/com/karankumar/booksapi/mutations/BookMutation.java
@@ -24,10 +24,12 @@ import com.netflix.graphql.dgs.DgsComponent;
 import com.netflix.graphql.dgs.DgsData;
 import graphql.schema.DataFetchingEnvironment;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Optional;
 
+@Secured("ROLE_ADMIN")
 @DgsComponent
 public class BookMutation {
     private final BookService bookService;


### PR DESCRIPTION
## Summary of change

Added spring-security with `ADMIN` role.
There is no use for a `USER` role by now since queries should be allowed for everyone.
If it is need it can be added easily.

Mutations are only allowed for `ADMIN` while queries are allowed for everyone.

## Related issue

Closes #69

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [ ] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

For any of the optional checkboxes (e.g. the screenshots one), still check it if it does not apply.

If in doubt, get in touch with us via our Slack workspace or by creating a new [Q&A discussion on GitHub](https://github.com/Project-Books/books-api/discussions/categories/q-a)
