### PR TITLE
Exclude BooksApiApplication.class and the Model package from Jacoco R…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,12 @@
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 				<version>0.8.7</version>
+				<configuration>
+					<excludes>
+						<exclude>com/karankumar/booksapi/BooksApiApplication.class</exclude>
+						<exclude>com/karankumar/booksapi/model/**</exclude>
+					</excludes>
+				</configuration>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>


### PR DESCRIPTION
Exclude BooksApiApplication.class and the Model package from Jacoco Report.

## Summary of change

Introduced exclusions in the jacoco plugin configuration. 
These exclusions are for `BooksApiApplication.class` and `Any class in the model package` as requested in the issue.

## Related issue

Closes #122 

## Pull request checklist

Please keep this checklist in & ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request

- [x] Created a branch that has a descriptive name (what your branch is for in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

For any of the optional checkboxes (e.g. the screenshots one), still check it if it does not apply.

If in doubt, get in touch with us via our Slack workspace or by creating a new [Q&A discussion on GitHub](https://github.com/Project-Books/books-api/discussions/categories/q-a)
